### PR TITLE
Remove github.com/Unknown/cae/zip dependency

### DIFF
--- a/install-go-deps.sh
+++ b/install-go-deps.sh
@@ -1,3 +1,2 @@
 go get -v github.com/robertkrimen/godocdown/godocdown
 go get -v github.com/alexcesaro/log
-go get -v github.com/Unknwon/cae/zip

--- a/spawn/helper_darwin.go
+++ b/spawn/helper_darwin.go
@@ -2,12 +2,10 @@ package spawn
 
 import (
 	"fmt"
+	"github.com/miketheprogrammer/go-thrust/common"
 	"io/ioutil"
 	"os"
 	"strings"
-
-	"github.com/Unknwon/cae/zip"
-	"github.com/miketheprogrammer/go-thrust/common"
 )
 
 /*
@@ -63,9 +61,9 @@ prepareExecutable dowloads, unzips and does alot of other magic to prepare our t
 */
 func prepareExecutable() {
 	path := downloadFromUrl(GetDownloadUrl(), "/tmp/$V", common.THRUST_VERSION)
-	//unzip(strings.Replace("/tmp/$V", "$V", common.THRUST_VERSION, 1), GetThrustDirectory())
-	zip.ExtractTo(path, GetThrustDirectory())
-
+	if err := unzip(path, GetThrustDirectory()); err != nil {
+		panic(err)
+	}
 	os.Rename(GetThrustDirectory()+"/ThrustShell.app/Contents/MacOS/ThrustShell", GetThrustDirectory()+"/ThrustShell.app/Contents/MacOS/"+common.ApplicationName)
 	os.Rename(GetThrustDirectory()+"/ThrustShell.app", GetThrustDirectory()+"/"+common.ApplicationName+".app")
 


### PR DESCRIPTION
This package seems to be useless (and implementation broken).

$ go build -o tutorial/bin/basic_window tutorial/basic_window.go
# github.com/miketheprogrammer/go-thrust/spawn

spawn/helper_darwin.go:67: undefined: "github.com/Unknwon/cae/zip".ExtractTo

Signed-off-by: Stéphane Depierrepont toorop@toorop.fr
