### PR TITLE
Adding SetTitle Method in Window bindings

### DIFF
--- a/lib/bindings/window/window.go
+++ b/lib/bindings/window/window.go
@@ -200,6 +200,17 @@ func (w *Window) Show() {
 	w.CallWhenReady(&command)
 }
 
+func (w *Window) SetTitle(title string) {
+	command := Command{
+		Method: "set_title",
+		Args: CommandArguments{
+			Title: title,
+		},
+	}
+
+	w.CallWhenDisplayed(&command)
+}
+
 func (w *Window) Maximize() {
 	command := Command{
 		Method: "maximize",


### PR DESCRIPTION
There is a specification for a `set_title` Method in the Thrust API docs
[github.com/breach/thrust/blob/master/docs/api/window.md](https://github.com/breach/thrust/blob/master/docs/api/window.md).