### PR TITLE
extended window bindings with a way to leave fullscreen / kiosk mode

### DIFF
--- a/lib/bindings/window/window.go
+++ b/lib/bindings/window/window.go
@@ -284,22 +284,22 @@ func (w *Window) UnFocus() {
 	w.CallWhenDisplayed(&command)
 }
 
-func (w *Window) Fullscreen() {
+func (w *Window) Fullscreen(fullscreen bool) {
 	command := Command{
 		Method: "set_fullscreen",
 		Args: CommandArguments{
-			Fullscreen: true,
+			Fullscreen: fullscreen,
 		},
 	}
 
 	w.CallWhenDisplayed(&command)
 }
 
-func (w *Window) Kiosk() {
+func (w *Window) Kiosk(kiosk bool) {
 	command := Command{
 		Method: "set_kiosk",
 		Args: CommandArguments{
-			Kiosk: true,
+			Kiosk: kiosk,
 		},
 	}
 


### PR DESCRIPTION
The current implementation of ```window.Fullscreen()``` makes it impossible to gracefully leave the fullscreen / kiosk mode without manually executing commands on the window itself.

This PR fixes it by extending both methods with a bool  ```window.Fullscreen(fullscreen bool)``` and ```window.Kiosk(kiosk bool)``` to set / unset the mode.