### PR TITLE
fix for a typo

### DIFF
--- a/lib/bindings/window/window.go
+++ b/lib/bindings/window/window.go
@@ -250,7 +250,7 @@ func (w *Window) UnMaximize() {
 
 func (w *Window) Minimize() {
 	command := Command{
-		Method: "minmize",
+		Method: "minimize",
 	}
 	w.CallWhenDisplayed(&command)
 }


### PR DESCRIPTION
Fix for a typo in lib/bindings/window/window.go