### PR TITLE
 enable icon_path (for windows builds)

### DIFF
--- a/lib/bindings/window/window.go
+++ b/lib/bindings/window/window.go
@@ -77,6 +77,7 @@ func NewWindow(options Options) *Window {
 			Title:    spawn.ApplicationName,
 			Size:     size,
 			HasFrame: !options.HasFrame,
+			IconPath: options.IconPath,
 		},
 	}
 	dispatcher.RegisterHandler(w.DispatchResponse)

--- a/lib/commands/commands.go
+++ b/lib/commands/commands.go
@@ -47,6 +47,7 @@ type CommandArguments struct {
 	Kiosk        bool          `json:"kiosk"`
 	Focus        bool          `json:"focus"`
 	HasFrame     bool          `json:"has_frame"`
+	IconPath     bool          `json:"icon_path,omitempty"`
 	Path         string        `json:"path,omitempty"`
 	Message      RemoteMessage `json:"message,omitempty"`
 }

--- a/lib/commands/commands.go
+++ b/lib/commands/commands.go
@@ -47,7 +47,7 @@ type CommandArguments struct {
 	Kiosk        bool          `json:"kiosk"`
 	Focus        bool          `json:"focus"`
 	HasFrame     bool          `json:"has_frame"`
-	IconPath     bool          `json:"icon_path,omitempty"`
+	IconPath     string        `json:"icon_path,omitempty"`
 	Path         string        `json:"path,omitempty"`
 	Message      RemoteMessage `json:"message,omitempty"`
 }


### PR DESCRIPTION
Because IconPath was missing in CommandArguments, this feature could not be used