### PR TITLE
Fix to window title and expected behavior of "HasFrame"

### DIFF
--- a/lib/bindings/window/window.go
+++ b/lib/bindings/window/window.go
@@ -74,9 +74,9 @@ func NewWindow(options Options) *Window {
 		ObjectType: "window",
 		Args: CommandArguments{
 			RootUrl:  w.Url,
-			Title:    spawn.ApplicationName,
+			Title:    options.Title, // Should be using the options.Title, not spawn.ApplicationName
 			Size:     size,
-			HasFrame: !options.HasFrame,
+			HasFrame: options.HasFrame, // This was reversed, HasFrame behavior should be 'true' (has frame) and 'false' (no frame)
 			IconPath: options.IconPath,
 		},
 	}


### PR DESCRIPTION
Fix to window title and expected behavior of "HasFrame"
1. Correction to Title to utilize the option.Title instead of spawn.ApplicationName (was incorrectly ignoring the options Title)
2. "HasFrame" expected behavior fix: 'true' for having a frame and 'false' for not having a frame.
